### PR TITLE
Create DampedLeastSquaresRedundant IK solver

### DIFF
--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(ik_solvers SHARED
   src/ForwardDynamicsSolver.cpp
   src/JacobianTransposeSolver.cpp
   src/DampedLeastSquaresSolver.cpp
+  src/DampedLeastSquaresRedundantSolver.cpp
   src/SelectivelyDampedLeastSquaresSolver.cpp
 )
 

--- a/cartesian_controller_base/ik_solver_plugin.xml
+++ b/cartesian_controller_base/ik_solver_plugin.xml
@@ -24,6 +24,14 @@
     </description>
   </class>
 
+  <class name="damped_least_squares_redundant"
+         type="cartesian_controller_base::DampedLeastSquaresRedundantSolver"
+         base_class_type="cartesian_controller_base::IKSolver">
+    <description>
+      A damped least squares (DLS) IK solver with joint centering for redundant manipulators
+    </description>
+  </class>
+
   <class name="selectively_damped_least_squares"
          type="cartesian_controller_base::SelectivelyDampedLeastSquaresSolver"
          base_class_type="cartesian_controller_base::IKSolver">

--- a/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresRedundantSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresRedundantSolver.h
@@ -1,0 +1,105 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    DampedLeastSquaresRedundantSolver.h
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \author  Gal Gorjup <galg@acumino.ai>
+ * \date    2025/07/04
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#ifndef DAMPED_LEAST_SQUARES_REDUNDANT_SOLVER_H_INCLUDED
+#define DAMPED_LEAST_SQUARES_REDUNDANT_SOLVER_H_INCLUDED
+
+#include <cartesian_controller_base/IKSolver.h>
+
+#include <kdl/jacobian.hpp>
+#include <memory>
+
+#include "rclcpp/node.hpp"
+
+namespace cartesian_controller_base
+{
+/**
+   * \brief A damped least squares IK solver for Cartesian controllers, 
+   * with joint centering for redundant manipulators
+   *
+   *
+   *  Implementation is based on the DampedLeastSquaresSolver, with an added term that 
+   *  tries to center the joints in their allowed range through null space projection.
+   */
+class DampedLeastSquaresRedundantSolver : public IKSolver
+{
+public:
+  DampedLeastSquaresRedundantSolver();
+  ~DampedLeastSquaresRedundantSolver();
+
+  /**
+     * \brief Compute joint target commands with damped least squares
+     *
+     * \param period The duration in sec for this simulation step
+     * \param net_force The applied net force, expressed in the root frame
+     *
+     * \return A point holding positions, velocities and accelerations of each joint
+     */
+  trajectory_msgs::msg::JointTrajectoryPoint getJointControlCmds(
+    rclcpp::Duration period, const ctrl::Vector6D & net_force) override;
+
+  /**
+     * \brief Initialize the solver
+     *
+     * \param nh A node handle for namespace-local parameter management
+     * \param chain The kinematic chain of the robot
+     * \param upper_pos_limits Tuple with max positive joint angles
+     * \param lower_pos_limits Tuple with max negative joint angles
+     *
+     * \return True, if everything went well
+     */
+
+  bool init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> nh, const KDL::Chain & chain,
+            const KDL::JntArray & upper_pos_limits,
+            const KDL::JntArray & lower_pos_limits) override;
+
+private:
+  std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
+  KDL::Jacobian m_jnt_jacobian;
+
+  // Dynamic parameters
+  const std::string m_params =
+    "solver.damped_least_squares_redundant";  ///< namespace for parameter access
+  double m_alpha;                             ///< damping coefficient
+};
+
+}  // namespace cartesian_controller_base
+
+#endif

--- a/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresRedundantSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresRedundantSolver.h
@@ -98,6 +98,7 @@ private:
   const std::string m_params =
     "solver.damped_least_squares_redundant";  ///< namespace for parameter access
   double m_alpha;                             ///< damping coefficient
+  double m_alpha_centering;                   ///< null space centering coefficient
 };
 
 }  // namespace cartesian_controller_base

--- a/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
+++ b/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
@@ -67,7 +67,10 @@ PLUGINLIB_EXPORT_CLASS(cartesian_controller_base::DampedLeastSquaresRedundantSol
 
 namespace cartesian_controller_base
 {
-DampedLeastSquaresRedundantSolver::DampedLeastSquaresRedundantSolver() : m_alpha(0.01) {}
+DampedLeastSquaresRedundantSolver::DampedLeastSquaresRedundantSolver()
+: m_alpha(0.01), m_alpha_centering(0.01)
+{
+}
 
 DampedLeastSquaresRedundantSolver::~DampedLeastSquaresRedundantSolver() {}
 

--- a/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
+++ b/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
@@ -1,0 +1,131 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+//-----------------------------------------------------------------------------
+/*!\file    DampedLeastSquaresRedundantSolver.cpp
+ *
+ * \author  Stefan Scherzinger <scherzin@fzi.de>
+ * \author  Gal Gorjup <galg@acumino.ai>
+ * \date    2025/07/04
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#include <cartesian_controller_base/DampedLeastSquaresRedundantSolver.h>
+
+#include <pluginlib/class_list_macros.hpp>
+
+/**
+ * \class cartesian_controller_base::DampedLeastSquaresRedundantSolver
+ *
+ * Users may explicitly specify this solver with \a "damped_least_squares_redundant" as \a
+ * ik_solver in their controllers.yaml configuration file for each controller:
+ *
+ * \code{.yaml}
+ * <name_of_your_controller>:
+ *   ros__parameters:
+ *     ik_solver: "damped_least_squares_redundant"
+ *     ...
+ *
+ *     solver:
+ *         ...
+ *         damped_least_squares_redundant:
+ *             alpha: 0.5
+ * \endcode
+ *
+ */
+PLUGINLIB_EXPORT_CLASS(cartesian_controller_base::DampedLeastSquaresRedundantSolver,
+                       cartesian_controller_base::IKSolver)
+
+namespace cartesian_controller_base
+{
+DampedLeastSquaresRedundantSolver::DampedLeastSquaresRedundantSolver() : m_alpha(0.01) {}
+
+DampedLeastSquaresRedundantSolver::~DampedLeastSquaresRedundantSolver() {}
+
+trajectory_msgs::msg::JointTrajectoryPoint DampedLeastSquaresRedundantSolver::getJointControlCmds(
+  rclcpp::Duration period, const ctrl::Vector6D & net_force)
+{
+  // Compute joint jacobian
+  m_jnt_jacobian_solver->JntToJac(m_current_positions, m_jnt_jacobian);
+
+  // Compute joint velocities according to:
+  // \f$ \dot{q} = ( J^T J + \alpha^2 I )^{-1} J^T f \f$
+  ctrl::MatrixND identity;
+  identity.setIdentity(m_number_joints, m_number_joints);
+  m_handle->get_parameter(m_params + ".alpha", m_alpha);
+
+  m_current_velocities.data =
+    (m_jnt_jacobian.data.transpose() * m_jnt_jacobian.data + m_alpha * m_alpha * identity)
+      .inverse() *
+    m_jnt_jacobian.data.transpose() * net_force;
+
+  // Integrate once, starting with zero motion
+  m_current_positions.data =
+    m_last_positions.data + 0.5 * m_current_velocities.data * period.seconds();
+
+  // Make sure positions stay in allowed margins
+  applyJointLimits();
+
+  // Apply results
+  trajectory_msgs::msg::JointTrajectoryPoint control_cmd;
+  for (int i = 0; i < m_number_joints; ++i)
+  {
+    control_cmd.positions.push_back(m_current_positions(i));
+    control_cmd.velocities.push_back(m_current_velocities(i));
+
+    // Accelerations should be left empty. Those values will be interpreted
+    // by most hardware joint drivers as max. tolerated values. As a
+    // consequence, the robot will move very slowly.
+  }
+  control_cmd.time_from_start = period;  // valid for this duration
+
+  // Update for the next cycle
+  m_last_positions = m_current_positions;
+
+  return control_cmd;
+}
+
+bool DampedLeastSquaresRedundantSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> nh,
+                                             const KDL::Chain & chain,
+                                             const KDL::JntArray & upper_pos_limits,
+                                             const KDL::JntArray & lower_pos_limits)
+{
+  IKSolver::init(nh, chain, upper_pos_limits, lower_pos_limits);
+
+  m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
+  m_jnt_jacobian.resize(m_number_joints);
+
+  auto_declare(m_params + ".alpha", 1.0);
+
+  return true;
+}
+
+}  // namespace cartesian_controller_base

--- a/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
+++ b/cartesian_controller_base/src/DampedLeastSquaresRedundantSolver.cpp
@@ -57,7 +57,8 @@
  *     solver:
  *         ...
  *         damped_least_squares_redundant:
- *             alpha: 0.5
+ *             alpha: 0.1
+ *             alpha_centering: 0.1
  * \endcode
  *
  */
@@ -81,11 +82,21 @@ trajectory_msgs::msg::JointTrajectoryPoint DampedLeastSquaresRedundantSolver::ge
   ctrl::MatrixND identity;
   identity.setIdentity(m_number_joints, m_number_joints);
   m_handle->get_parameter(m_params + ".alpha", m_alpha);
+  m_handle->get_parameter(m_params + ".alpha_centering", m_alpha_centering);
 
-  m_current_velocities.data =
+  // Damped least squares pseudo-inverse
+  Eigen::MatrixXd jacobian_pinv =
     (m_jnt_jacobian.data.transpose() * m_jnt_jacobian.data + m_alpha * m_alpha * identity)
       .inverse() *
-    m_jnt_jacobian.data.transpose() * net_force;
+    m_jnt_jacobian.data.transpose();
+  Eigen::MatrixXd nullspace_projector = identity - jacobian_pinv * m_jnt_jacobian.data;
+
+  // Secondary objective: joint centering
+  Eigen::VectorXd jnt_centers = 0.5 * (m_upper_pos_limits.data + m_lower_pos_limits.data);
+  Eigen::VectorXd centering_loss = -m_alpha_centering * (m_current_positions.data - jnt_centers);
+
+  // Compute joint velocities
+  m_current_velocities.data = jacobian_pinv * net_force + nullspace_projector * centering_loss;
 
   // Integrate once, starting with zero motion
   m_current_positions.data =
@@ -123,7 +134,8 @@ bool DampedLeastSquaresRedundantSolver::init(std::shared_ptr<rclcpp_lifecycle::L
   m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
   m_jnt_jacobian.resize(m_number_joints);
 
-  auto_declare(m_params + ".alpha", 1.0);
+  auto_declare(m_params + ".alpha", 0.01);
+  auto_declare(m_params + ".alpha_centering", 0.01);
 
   return true;
 }


### PR DESCRIPTION
Create DLS solver with a secondary joint centering objective for redundant robots.

This is essentially a duplication of the existing DLS solver, with added null space projection (see b79fc26941fae32db3c00e1d06abb8a34bcbc2b0).