### PR TITLE
Publish joint commands from cartesian controller

### DIFF
--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package(trajectory_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(urdf REQUIRED)
 find_package(realtime_tools REQUIRED)
+find_package(std_msgs REQUIRED)
 
 
 # Convenience variable for dependencies

--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -38,7 +38,7 @@ find_package(trajectory_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(urdf REQUIRED)
 find_package(realtime_tools REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(control_msgs REQUIRED)
 
 
 # Convenience variable for dependencies

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -45,6 +45,7 @@
 #include <cartesian_controller_base/Utility.h>
 #include <realtime_tools/realtime_publisher.h>
 
+#include <control_msgs/msg/joint_jog.hpp>
 #include <controller_interface/controller_interface.hpp>
 #include <functional>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -56,7 +57,6 @@
 #include <memory>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <std_msgs/msg/float64_multi_array.hpp>
 #include <string>
 #include <trajectory_msgs/msg/joint_trajectory_point.hpp>
 #include <vector>
@@ -225,7 +225,7 @@ private:
   realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::msg::TwistStamped>
     m_feedback_twist_publisher;
   bool m_publish_joint_cmd;
-  realtime_tools::RealtimePublisherSharedPtr<std_msgs::msg::Float64MultiArray> m_feedback_joint_cmd;
+  realtime_tools::RealtimePublisherSharedPtr<control_msgs::msg::JointJog> m_feedback_joint_cmd;
   std::vector<double> m_joint_cmds_values;
 
   std::vector<std::string> m_cmd_interface_types;

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -56,6 +56,7 @@
 #include <memory>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
 #include <string>
 #include <trajectory_msgs/msg/joint_trajectory_point.hpp>
 #include <vector>
@@ -223,6 +224,9 @@ private:
     m_feedback_pose_publisher;
   realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::msg::TwistStamped>
     m_feedback_twist_publisher;
+  bool m_publish_joint_cmd;
+  realtime_tools::RealtimePublisherSharedPtr<std_msgs::msg::Float64MultiArray> m_feedback_joint_cmd;
+  std::vector<double> m_joint_cmds_values;
 
   std::vector<std::string> m_cmd_interface_types;
   std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>>

--- a/cartesian_controller_base/package.xml
+++ b/cartesian_controller_base/package.xml
@@ -17,9 +17,10 @@
   <depend>trajectory_msgs</depend>
   <depend>pluginlib</depend>
   <depend>realtime_tools</depend>
+  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>
-    <cartesian_controller_base plugin="${prefix}/ik_solver_plugin.xml"/>
+    <cartesian_controller_base plugin="${prefix}/ik_solver_plugin.xml" />
   </export>
 </package>

--- a/cartesian_controller_base/package.xml
+++ b/cartesian_controller_base/package.xml
@@ -17,7 +17,7 @@
   <depend>trajectory_msgs</depend>
   <depend>pluginlib</depend>
   <depend>realtime_tools</depend>
-  <depend>std_msgs</depend>
+  <depend>control_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -402,6 +402,7 @@ void CartesianControllerBase::writeJointControlCmds()
 
   if (m_publish_joint_cmd && m_feedback_joint_cmd->trylock())
   {
+    m_feedback_joint_cmd->msg_.header.stamp = get_node()->get_clock()->now();
     if (is_position)
     {
       m_feedback_joint_cmd->msg_.displacements = m_joint_cmds_values;

--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -251,10 +251,10 @@ CartesianControllerBase::on_configure(const rclcpp_lifecycle::State & previous_s
 
   m_publish_joint_cmd = get_node()->get_parameter("solver.publish_cmds").as_bool();
   m_feedback_joint_cmd =
-    std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Float64MultiArray>>(
-      get_node()->create_publisher<std_msgs::msg::Float64MultiArray>(
+    std::make_shared<realtime_tools::RealtimePublisher<control_msgs::msg::JointJog>>(
+      get_node()->create_publisher<control_msgs::msg::JointJog>(
         std::string(get_node()->get_name()) + "/joint_cmd", 3));
-  m_feedback_joint_cmd->msg_.data.reserve(m_joint_names.size());
+  m_feedback_joint_cmd->msg_.joint_names = m_joint_names;
   m_joint_cmds_values.reserve(m_joint_names.size());
   for (size_t i = 0; i < m_joint_names.size(); i++)
   {
@@ -378,6 +378,7 @@ void CartesianControllerBase::writeJointControlCmds()
   }
 
   // Write all available types.
+  bool is_position = true;
   for (const auto & type : m_cmd_interface_types)
   {
     if (type == hardware_interface::HW_IF_POSITION)
@@ -390,6 +391,7 @@ void CartesianControllerBase::writeJointControlCmds()
     }
     if (type == hardware_interface::HW_IF_VELOCITY)
     {
+      is_position = false;
       for (size_t i = 0; i < m_joint_names.size(); ++i)
       {
         m_joint_cmd_vel_handles[i].get().set_value(m_simulated_joint_motion.velocities[i]);
@@ -400,7 +402,14 @@ void CartesianControllerBase::writeJointControlCmds()
 
   if (m_publish_joint_cmd && m_feedback_joint_cmd->trylock())
   {
-    m_feedback_joint_cmd->msg_.data = m_joint_cmds_values;
+    if (is_position)
+    {
+      m_feedback_joint_cmd->msg_.displacements = m_joint_cmds_values;
+    }
+    else
+    {
+      m_feedback_joint_cmd->msg_.velocities = m_joint_cmds_values;
+    }
     m_feedback_joint_cmd->unlockAndPublish();
   }
 }

--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -100,6 +100,7 @@ CartesianControllerBase::on_init()
     auto_declare<double>("solver.error_scale", 1.0);
     auto_declare<int>("solver.iterations", 1);
     auto_declare<bool>("solver.publish_state_feedback", false);
+    auto_declare<bool>("solver.publish_cmds", false);
     m_initialized = true;
   }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -248,6 +249,18 @@ CartesianControllerBase::on_configure(const rclcpp_lifecycle::State & previous_s
       get_node()->create_publisher<geometry_msgs::msg::TwistStamped>(
         std::string(get_node()->get_name()) + "/current_twist", 3));
 
+  m_publish_joint_cmd = get_node()->get_parameter("solver.publish_cmds").as_bool();
+  m_feedback_joint_cmd =
+    std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Float64MultiArray>>(
+      get_node()->create_publisher<std_msgs::msg::Float64MultiArray>(
+        std::string(get_node()->get_name()) + "/joint_cmd", 3));
+  m_feedback_joint_cmd->msg_.data.reserve(m_joint_names.size());
+  m_joint_cmds_values.reserve(m_joint_names.size());
+  for (size_t i = 0; i < m_joint_names.size(); i++)
+  {
+    m_joint_cmds_values.emplace_back(0);
+  }
+
   m_configured = true;
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -372,6 +385,7 @@ void CartesianControllerBase::writeJointControlCmds()
       for (size_t i = 0; i < m_joint_names.size(); ++i)
       {
         m_joint_cmd_pos_handles[i].get().set_value(m_simulated_joint_motion.positions[i]);
+        m_joint_cmds_values[i] = m_simulated_joint_motion.positions[i];
       }
     }
     if (type == hardware_interface::HW_IF_VELOCITY)
@@ -379,8 +393,15 @@ void CartesianControllerBase::writeJointControlCmds()
       for (size_t i = 0; i < m_joint_names.size(); ++i)
       {
         m_joint_cmd_vel_handles[i].get().set_value(m_simulated_joint_motion.velocities[i]);
+        m_joint_cmds_values[i] = m_simulated_joint_motion.velocities[i];
       }
     }
+  }
+
+  if (m_publish_joint_cmd && m_feedback_joint_cmd->trylock())
+  {
+    m_feedback_joint_cmd->msg_.data = m_joint_cmds_values;
+    m_feedback_joint_cmd->unlockAndPublish();
   }
 }
 


### PR DESCRIPTION
This PR adds the option to publish target joint commands from the cartesian controller. This is useful in scenarios where it's important to have the joint space input information.

# Summary of contributions
- Added std_msgs dependency.
- Added parameter `solver.publish_cmds` to control if target joint commands should be published or not.